### PR TITLE
Handle grayscale font atlases in SDF font loader

### DIFF
--- a/Sharp2D/Sharp2D/Fonts/SdfFont.cs
+++ b/Sharp2D/Sharp2D/Fonts/SdfFont.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Xml.Linq;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
+using SkiaSharp;
 
 namespace Sharp2D.Fonts
 {
@@ -192,6 +193,9 @@ namespace Sharp2D.Fonts
         private static void LoadTexture(string atlasPath, SdfFont font)
         {
             var tex = Texture.NewTexture(atlasPath);
+            // The SDF atlas is a single-channel image. Use an 8-bit grayscale bitmap so we
+            // can upload it to OpenGL as a red channel texture.
+            tex.ColorType = SKColorType.Gray8;
             tex.MinFilter = (int)TextureMinFilter.Linear;
             tex.MagFilter = (int)TextureMagFilter.Linear;
             tex.LoadTextureFromFile();

--- a/Sharp2D/Sharp2D/Game/Sprites/TileSprite.cs
+++ b/Sharp2D/Sharp2D/Game/Sprites/TileSprite.cs
@@ -133,8 +133,8 @@ namespace Sharp2D.Game.Sprites
                 int height = TileSet.TileHeight;
 
 
-                // Create a new SKBitmap to hold the tile image.
-                SKBitmap testBmp = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+                // Create a new SKBitmap to hold the tile image using the texture's color type.
+                SKBitmap testBmp = new SKBitmap(width, height, Texture.ColorType, SKAlphaType.Premul);
                 using (var canvas = new SKCanvas(testBmp))
                 {
                     // Define destination and source rectangles.


### PR DESCRIPTION
## Summary
- support uploading Gray8 textures by mapping to GL_RED/R8
- load SDF font atlases as 8-bit grayscale instead of RGBA
- expose `PixelFormat` and `PixelInternalFormat` getters on `Texture` and use them when uploading pixel data

## Testing
- `dotnet build Sharp2D/Sharp2D.sln -c Debug`


------
https://chatgpt.com/codex/tasks/task_e_68a646378e80832ab637b574fcc2aa85