### PR TITLE
docs: expand animation and modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,54 @@ player.Texture.LoadTextureFromFile();
 world.AddSprite(player);
 ```
 
+### Sprite Modules
+
+Sprites that inherit from `ModuleSprite` can be extended with reusable pieces of
+functionality called *modules*. Attach a module with `AttachModule<T>()` and it
+will receive update calls each frame.
+
+```csharp
+public class BlinkModule : IModule
+{
+    public Sprite Owner { get; private set; }
+    public string ModuleName => "Blink";
+    public ModuleRules Rules => ModuleRules.None;
+
+    public void InitializeWith(Sprite sprite)
+    {
+        Owner = sprite;
+    }
+
+    public void OnUpdate()
+    {
+        Owner.IsVisible = !Owner.IsVisible;
+    }
+
+    public void Dispose() { }
+}
+
+// Attach the custom module
+player.AttachModule<BlinkModule>();
+```
+
 ### Animation
 
-Attach an `AnimationModule` to a sprite to play animations:
+Animations are configured through a JSON file that describes the sprite sheet
+and each animation's frames. Place the file in `animations/` and by default the
+module will look for a file matching the sprite's name, e.g.
+`animations/player.conf`:
+
+```json
+{
+  "width": 32,
+  "height": 32,
+  "animations": {
+    "walk": { "row": 0, "framecount": 4, "speed": 100 }
+  }
+}
+```
+
+Attach an `AnimationModule` to the sprite and trigger an animation:
 
 ```csharp
 var animations = player.AttachModule<AnimationModule>();


### PR DESCRIPTION
## Summary
- document attaching sprite modules and custom module example
- expand animation section with configuration and setup details

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ab5a4737e8832a8a834efccbf33c96